### PR TITLE
mysqldump backup input module

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ To clean up after you finish with tests:
 docker kill test_mysql
 docker rm test_mysql
 ```
+To run tests against MySQLDump module, first make sure that you have `mysqldump` binary
+available in `$PATH` and then proceed with the following commands: 
+```
+docker run --name test_mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test -d percona:latest
+docker exec -i test_mysql mysql -hlocalhost -uroot -proot test < samples/mysql.sql
+cd modules/backup/input/mysqldump/
+go test -v -cover
+```
+To clean up after you finish with tests: 
+```
+docker kill test_mysql
+docker rm test_mysql
+```
 To run tests against Postgres module proceed with the following commands: 
 ```
 docker run --name test_postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=test -d postgres:latest

--- a/common/app.go
+++ b/common/app.go
@@ -7,6 +7,7 @@ import (
 	"github.com/copybird/copybird/modules/backup/encrypt/aesgcm"
 	"github.com/copybird/copybird/modules/backup/input/mongodb"
 	"github.com/copybird/copybird/modules/backup/input/mysql"
+	"github.com/copybird/copybird/modules/backup/input/mysqldump"
 	postgres "github.com/copybird/copybird/modules/backup/input/postgresql"
 	"github.com/copybird/copybird/modules/backup/output/gcp"
 	"github.com/copybird/copybird/modules/backup/output/http"
@@ -66,6 +67,7 @@ func cmdCallback(f func() error) func(cmd *cobra.Command, args []string) {
 
 func (a *App) registerModules() {
 	core.RegisterModule(&mysql.BackupInputMysql{})
+	core.RegisterModule(&mysqldump.BackupInputMysqlDump{})
 	core.RegisterModule(&postgres.BackupInputPostgresql{})
 	core.RegisterModule(&mongodb.BackupInputMongodb{})
 	core.RegisterModule(&gzip.BackupCompressGzip{})

--- a/modules/backup/input/mysqldump/config.go
+++ b/modules/backup/input/mysqldump/config.go
@@ -1,0 +1,10 @@
+package mysqldump
+
+// MySQLDumpConfig stores configuration for Mysqldump utility
+type MySQLDumpConfig struct {
+	Host     string
+	Port     string
+	Username string
+	Password string
+	Database string
+}

--- a/modules/backup/input/mysqldump/config.go
+++ b/modules/backup/input/mysqldump/config.go
@@ -2,9 +2,14 @@ package mysqldump
 
 // MySQLDumpConfig stores configuration for Mysqldump utility
 type MySQLDumpConfig struct {
-	Host     string
-	Port     string
-	Username string
-	Password string
-	Database string
+	Host              string
+	Port              string
+	Username          string
+	Password          string
+	Database          string
+	Routines          bool
+	Events            bool
+	Triggers          bool
+	SingleTransaction bool
+	ColumnStatistics  bool
 }

--- a/modules/backup/input/mysqldump/mysqldump.go
+++ b/modules/backup/input/mysqldump/mysqldump.go
@@ -85,6 +85,11 @@ func (m *BackupInputMysqlDump) InitModule(cfg interface{}) error {
 		fmt.Sprintf("-P%s", m.config.Port),
 		fmt.Sprintf("-u%s", m.config.Username),
 		fmt.Sprintf("-p%s", m.config.Password),
+		"--column-statistics=0",
+		"--single-transaction",
+		"--triggers",
+		"--routines",
+		"--events",
 		m.config.Database,
 	}
 

--- a/modules/backup/input/mysqldump/mysqldump.go
+++ b/modules/backup/input/mysqldump/mysqldump.go
@@ -57,11 +57,16 @@ func (m *BackupInputMysqlDump) GetName() string {
 // GetConfig returns config of module
 func (m *BackupInputMysqlDump) GetConfig() interface{} {
 	return &MySQLDumpConfig{
-		Host:     "127.0.0.1",
-		Port:     "3306",
-		Username: "root",
-		Password: "root",
-		Database: "test",
+		Host:              "127.0.0.1",
+		Port:              "3306",
+		Username:          "root",
+		Password:          "root",
+		Database:          "test",
+		Routines:          true,
+		Events:            true,
+		Triggers:          true,
+		SingleTransaction: true,
+		ColumnStatistics:  false,
 	}
 }
 
@@ -85,11 +90,11 @@ func (m *BackupInputMysqlDump) InitModule(cfg interface{}) error {
 		fmt.Sprintf("-P%s", m.config.Port),
 		fmt.Sprintf("-u%s", m.config.Username),
 		fmt.Sprintf("-p%s", m.config.Password),
-		"--column-statistics=0",
-		"--single-transaction",
-		"--triggers",
-		"--routines",
-		"--events",
+		fmt.Sprintf("--triggers=%t", m.config.Triggers),
+		fmt.Sprintf("--routines=%t", m.config.Routines),
+		fmt.Sprintf("--events=%t", m.config.Events),
+		fmt.Sprintf("--single-transaction=%t", m.config.SingleTransaction),
+		fmt.Sprintf("--column-statistics=%t", m.config.ColumnStatistics),
 		m.config.Database,
 	}
 

--- a/modules/backup/input/mysqldump/mysqldump.go
+++ b/modules/backup/input/mysqldump/mysqldump.go
@@ -1,0 +1,102 @@
+package mysqldump
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/copybird/copybird/core"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// Module Constants
+const GroupName = "backup"
+const TypeName = "input"
+const ModuleName = "mysqldump"
+
+type (
+	// BackupInputMysqlDump is struct storing inner properties for mysql backups
+	BackupInputMysqlDump struct {
+		core.Module
+		command string
+		args    []string
+		config  *MySQLDumpConfig
+		reader  io.Reader
+		writer  io.Writer
+	}
+	dumpHeader struct {
+		Version string
+	}
+	dumpFooter struct {
+		EndTime string
+	}
+	table struct {
+		Name   string
+		Schema string
+		Data   string
+	}
+)
+
+// GetGroup returns group
+func (m *BackupInputMysqlDump) GetGroup() core.ModuleGroup {
+	return GroupName
+}
+
+// GetType returns type
+func (m *BackupInputMysqlDump) GetType() core.ModuleType {
+	return TypeName
+}
+
+// GetName returns name of module
+func (m *BackupInputMysqlDump) GetName() string {
+	return ModuleName
+}
+
+// GetConfig returns config of module
+func (m *BackupInputMysqlDump) GetConfig() interface{} {
+	return &MySQLDumpConfig{
+		Host:     "127.0.0.1",
+		Port:     "3306",
+		Username: "root",
+		Password: "root",
+		Database: "test",
+	}
+}
+
+// InitPipe initializes pipe
+func (m *BackupInputMysqlDump) InitPipe(w io.Writer, r io.Reader) error {
+	m.reader = r
+	m.writer = w
+	return nil
+}
+
+// InitModule initializes module
+func (m *BackupInputMysqlDump) InitModule(cfg interface{}) error {
+	m.config = cfg.(*MySQLDumpConfig)
+
+	command, err := exec.LookPath("mysqldump")
+	if err != nil {
+		return fmt.Errorf("%s cannot be found", command)
+	}
+	args := []string{
+		fmt.Sprintf("-h%s", m.config.Host),
+		fmt.Sprintf("-P%s", m.config.Port),
+		fmt.Sprintf("-u%s", m.config.Username),
+		fmt.Sprintf("-p%s", m.config.Password),
+		m.config.Database,
+	}
+
+	m.command = command
+	m.args = args
+	return nil
+}
+
+// Run dumps database
+func (m *BackupInputMysqlDump) Run() error {
+	cmd := exec.Command(m.command, m.args...)
+	cmd.Stdout = m.writer
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/modules/backup/input/mysqldump/mysqldump_test.go
+++ b/modules/backup/input/mysqldump/mysqldump_test.go
@@ -1,0 +1,25 @@
+package mysqldump
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMysqlDumpRun(t *testing.T) {
+	m := &BackupInputMysqlDump{}
+	c := m.GetConfig().(*MySQLDumpConfig)
+	c.Host = "127.0.0.1"
+	c.Port = "3306"
+	c.Username = "root"
+	c.Password = "root"
+	c.Database = "test"
+
+	require.NoError(t, m.InitModule(c))
+	buf := bytes.Buffer{}
+	assert.NoError(t, m.InitPipe(&buf, nil))
+	assert.NoError(t, m.Run())
+	t.Log(buf.String())
+}


### PR DESCRIPTION
mysqldump backup input module based on os.exec of `mysqldump` binary from mysql-client package. Usage example:
```
copybird backup -i "mysqldump::host=127.0.0.1::username=root::password=root::database=test" -o "local::file=dump.sql"
``` 