### PR TITLE
os.Exit(1) on module errors

### DIFF
--- a/common/app.go
+++ b/common/app.go
@@ -14,7 +14,6 @@ import (
 	"github.com/copybird/copybird/modules/backup/output/s3"
 	"github.com/copybird/copybird/modules/backup/output/scp"
 	"github.com/spf13/cobra"
-	"log"
 	//"log"
 	//"github.com/spf13/cobra"
 )
@@ -34,20 +33,23 @@ func NewApp() *App {
 
 func (a *App) Run() error {
 	a.registerModules()
-	var rootCmd = &cobra.Command{Use: "copybird"}
+	var rootCmd = &cobra.Command{
+		Use:          "copybird",
+		SilenceUsage: true,
+	}
 	a.cmdBackup = &cobra.Command{
 		Use:   "backup",
 		Short: "Start new backup",
 		Long:  ``,
 		Args:  cobra.MinimumNArgs(0),
-		Run:   cmdCallback(a.DoBackup),
+		RunE:  cmdCallback(a.DoBackup),
 	}
 	a.cmdRestore = &cobra.Command{
 		Use:   "restore",
 		Short: "Start new restore",
 		Long:  ``,
 		Args:  cobra.MinimumNArgs(0),
-		Run:   cmdCallback(a.DoRestore),
+		RunE:  cmdCallback(a.DoRestore),
 	}
 	rootCmd.AddCommand(a.cmdBackup)
 	rootCmd.AddCommand(a.cmdRestore)
@@ -55,12 +57,9 @@ func (a *App) Run() error {
 	return rootCmd.Execute()
 }
 
-func cmdCallback(f func() error) func(cmd *cobra.Command, args []string) {
-	return func(cmd *cobra.Command, args []string) {
-		err := f()
-		if err != nil {
-			log.Printf("cmd err: %s", err)
-		}
+func cmdCallback(f func() error) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		return f()
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	go.mongodb.org/mongo-driver v1.0.3
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/api v0.6.0
 	google.golang.org/appengine v1.6.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/copybird/copybird/common"
 )
@@ -10,5 +11,6 @@ func main() {
 	app := common.NewApp()
 	if err := app.Run(); err != nil {
 		log.Printf("run err: %s", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
- WaitGroup replaced with ErrGroup to collect module errors
- CLI usage silenced for cleaner output

Not implemented:
- Context handling inside modules: fail fast if one of the module failed