### PR TITLE
Execution context passed to modules

### DIFF
--- a/common/runner.go
+++ b/common/runner.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"io"
 	"log"
 	"sync"
@@ -59,7 +60,7 @@ func (r *Runner) runModule(module core.Module, writer io.Writer, reader io.Reade
 		chanError <- &core.ModuleError{Module: module, Err: err}
 		return
 	}
-	err = module.Run()
+	err = module.Run(context.TODO())
 	if err != nil {
 		chanError <- &core.ModuleError{Module: module, Err: err}
 	}

--- a/core/module.go
+++ b/core/module.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"io"
 )
 
@@ -10,7 +11,7 @@ type Module interface {
 	GetType() ModuleType
 	GetConfig() interface{}
 	InitModule(cfg interface{}) error
-	Run() error
+	Run(ctx context.Context) error
 	Close() error
 	InitPipe(w io.Writer, r io.Reader) error
 }

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,7 @@ github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73t
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
@@ -262,6 +263,7 @@ google.golang.org/api v0.6.0/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/modules/backup/compress/gzip/gzip.go
+++ b/modules/backup/compress/gzip/gzip.go
@@ -2,6 +2,7 @@ package gzip
 
 import (
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -48,7 +49,7 @@ func (m *BackupCompressGzip) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *BackupCompressGzip) Run() error {
+func (m *BackupCompressGzip) Run(ctx context.Context) error {
 	gw, err := gzip.NewWriterLevel(m.writer, m.level)
 	if err != nil {
 		return fmt.Errorf("cant start gzip writer with error: %s", err)

--- a/modules/backup/compress/gzip/gzip_test.go
+++ b/modules/backup/compress/gzip/gzip_test.go
@@ -3,6 +3,7 @@ package gzip
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestCompress_Run_Success_Compress(t *testing.T) {
 
 	_ = compressor.InitModule(&cfg)
 	_ = compressor.InitPipe(wb, rb)
-	err := compressor.Run()
+	err := compressor.Run(context.TODO())
 	assert.Equal(t, err, nil)
 
 	var buff2 = new(bytes.Buffer)

--- a/modules/backup/compress/lz4/lz4.go
+++ b/modules/backup/compress/lz4/lz4.go
@@ -1,10 +1,12 @@
 package lz4
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"github.com/copybird/copybird/core"
 	"io"
+
+	"github.com/copybird/copybird/core"
 
 	"github.com/pierrec/lz4"
 )
@@ -57,7 +59,7 @@ func (m *BackupCompressLz4) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *BackupCompressLz4) Run() error {
+func (m *BackupCompressLz4) Run(ctx context.Context) error {
 	lw := lz4.NewWriter(m.writer)
 	lw.Header = lz4.Header{CompressionLevel: m.level}
 	defer lw.Close()

--- a/modules/backup/compress/lz4/lz4_test.go
+++ b/modules/backup/compress/lz4/lz4_test.go
@@ -2,6 +2,7 @@ package lz4
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestCompressLZ4(t *testing.T) {
 				return
 			}
 
-			err = comp.Run()
+			err = comp.Run(context.TODO())
 			if err != nil {
 				panic(err)
 			}

--- a/modules/backup/encrypt/aesgcm/aesgcm.go
+++ b/modules/backup/encrypt/aesgcm/aesgcm.go
@@ -2,6 +2,7 @@ package aesgcm
 
 import (
 	"bufio"
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -72,14 +73,14 @@ func (m *BackupEncryptAesgcm) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *BackupEncryptAesgcm) Run() error {
+func (m *BackupEncryptAesgcm) Run(ctx context.Context) error {
 	var err error
 	var n int
 
 	nonce := make([]byte, 12)
 
 	originaData := make([]byte, BUF_SIZE)
-	encryptedData := make([]byte, BUF_SIZE +  m.gcm.Overhead())
+	encryptedData := make([]byte, BUF_SIZE+m.gcm.Overhead())
 
 	for {
 		n, err = m.reader.Read(originaData)

--- a/modules/backup/encrypt/aesgcm/aesgcm_test.go
+++ b/modules/backup/encrypt/aesgcm/aesgcm_test.go
@@ -2,6 +2,7 @@ package aesgcm
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"gotest.tools/assert"
@@ -16,6 +17,6 @@ func TestEncryptionAESGCM(t *testing.T) {
 	assert.Assert(t, enc.GetConfig() != nil)
 	assert.NilError(t, enc.InitPipe(bufOutput, bufInput))
 	assert.NilError(t, enc.InitModule(&Config{Key: key}))
-	assert.NilError(t, enc.Run())
+	assert.NilError(t, enc.Run(context.TODO()))
 	assert.NilError(t, enc.Close())
 }

--- a/modules/backup/input/consul/consul.go
+++ b/modules/backup/input/consul/consul.go
@@ -57,7 +57,7 @@ func (b *BackupInputConsul) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (b *BackupInputConsul) Run() error {
+func (b *BackupInputConsul) Run(ctx context.Context) error {
 	return nil
 }
 

--- a/modules/backup/input/etcd/etcd.go
+++ b/modules/backup/input/etcd/etcd.go
@@ -69,7 +69,7 @@ func (b *BackupInputEtcd) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (b *BackupInputEtcd) Run() error {
+func (b *BackupInputEtcd) Run(ctx context.Context) error {
 	resp, err := b.api.Get(context.TODO(), b.config.Key, &client.GetOptions{Recursive: true})
 	if err != nil {
 		return err

--- a/modules/backup/input/etcd/etcd_test.go
+++ b/modules/backup/input/etcd/etcd_test.go
@@ -24,7 +24,7 @@ func TestEtcdBackup(t *testing.T) {
 	a.Set(context.TODO(), conf.Key+"/test", "World", nil)
 	a.Set(context.TODO(), conf.Key+"/dir", "Hey", &o)
 	a.Set(context.TODO(), conf.Key+"/dir/name", "Value", nil)
-	assert.NoError(t, b.Run())
+	assert.NoError(t, b.Run(context.TODO()))
 	a.Delete(context.TODO(), conf.Key, &client.DeleteOptions{Recursive: true})
 
 }

--- a/modules/backup/input/etcdv3/etcdv3.go
+++ b/modules/backup/input/etcdv3/etcdv3.go
@@ -69,7 +69,7 @@ func (b *BackupInputEtcd) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (b *BackupInputEtcd) Run() error {
+func (b *BackupInputEtcd) Run(ctx context.Context) error {
 	resp, err := b.api.Get(context.TODO(), b.config.Key)
 	if err != nil {
 		return err

--- a/modules/backup/input/etcdv3/etcdv3_test.go
+++ b/modules/backup/input/etcdv3/etcdv3_test.go
@@ -23,7 +23,7 @@ func TestEtcdBackup(t *testing.T) {
 	a.Put(context.TODO(), conf.Key+"/test", "World")
 	a.Put(context.TODO(), conf.Key+"/dir", "Hey")
 	a.Put(context.TODO(), conf.Key+"/dir/name", "Value")
-	assert.NoError(t, b.Run())
+	assert.NoError(t, b.Run(context.TODO()))
 	a.Delete(context.TODO(), conf.Key, clientv3.WithPrefix())
 
 }

--- a/modules/backup/input/local/local.go
+++ b/modules/backup/input/local/local.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -58,7 +59,7 @@ func (b *BackupInputLocal) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (b *BackupInputLocal) Run() error {
+func (b *BackupInputLocal) Run(ctx context.Context) error {
 	f, err := os.Open(b.config.Filename)
 	if err != nil {
 		return err

--- a/modules/backup/input/local/local_test.go
+++ b/modules/backup/input/local/local_test.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ func TestLocalInput(t *testing.T) {
 	assert.NoError(t, b.InitPipe(wr, nil))
 	assert.NoError(t, b.InitModule(&Config{Filename: "test.file"}))
 	assert.Equal(t, &Config{}, b.GetConfig())
-	assert.NoError(t, b.Run())
+	assert.NoError(t, b.Run(context.TODO()))
 	assert.Equal(t, "test\n", wr.String())
 
 }

--- a/modules/backup/input/mongodb/mongo.go
+++ b/modules/backup/input/mongodb/mongo.go
@@ -84,7 +84,7 @@ func (m *BackupInputMongodb) InitModule(cfg interface{}) error {
 }
 
 // Run runs module
-func (m *BackupInputMongodb) Run() error {
+func (m *BackupInputMongodb) Run(ctx context.Context) error {
 	m.startTimestamp = time.Now()
 
 	dbs, err := m.getDatabases(m.rootCtx)

--- a/modules/backup/input/mysql/mysql.go
+++ b/modules/backup/input/mysql/mysql.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -115,7 +116,7 @@ func (m *BackupInputMysql) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (m *BackupInputMysql) Run() error {
+func (m *BackupInputMysql) Run(ctx context.Context) error {
 	return m.dumpDatabase()
 }
 

--- a/modules/backup/input/mysql/mysql_test.go
+++ b/modules/backup/input/mysql/mysql_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestGetTables(t *testing.T) {
 	tableSchema, err := m.getTableSchema(tables[0])
 	assert.NoError(t, err)
 	assert.Equal(t, authorsSchema, tableSchema)
-	err = m.Run()
+	err = m.Run(context.TODO())
 	assert.NoError(t, err)
 	assert.NoError(t, os.Remove("dump.sql"))
 }
@@ -50,6 +51,6 @@ func TestMysqlDump(t *testing.T) {
 	require.NoError(t, m.InitModule(c))
 	buf := bytes.Buffer{}
 	require.NoError(t, m.InitPipe(&buf, nil))
-	assert.NoError(t, m.Run())
+	assert.NoError(t, m.Run(context.TODO()))
 	t.Log(buf.String())
 }

--- a/modules/backup/input/postgresql/postgresql.go
+++ b/modules/backup/input/postgresql/postgresql.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"strconv"
@@ -89,7 +90,7 @@ func (m *BackupInputPostgresql) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (m *BackupInputPostgresql) Run() error {
+func (m *BackupInputPostgresql) Run(ctx context.Context) error {
 
 	if err := m.dumpDatabase(); err != nil {
 		return err

--- a/modules/backup/input/postgresql/postgresql_test.go
+++ b/modules/backup/input/postgresql/postgresql_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -42,7 +43,7 @@ func TestGetTables(t *testing.T) {
 
 	assert.NoError(t, d.dumpDatabase())
 
-	assert.NoError(t, d.Run())
+	assert.NoError(t, d.Run(context.TODO()))
 
 	assert.NoError(t, os.Remove("dump.sql"))
 }

--- a/modules/backup/input/tar/tar.go
+++ b/modules/backup/input/tar/tar.go
@@ -2,6 +2,7 @@ package tar
 
 import (
 	"archive/tar"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -62,7 +63,7 @@ func (b *BackupInputTar) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (b *BackupInputTar) Run() error {
+func (b *BackupInputTar) Run(ctx context.Context) error {
 	if _, err := os.Stat(b.config.DirectoryPath); err != nil {
 		return err
 	}

--- a/modules/backup/input/tar/tar_test.go
+++ b/modules/backup/input/tar/tar_test.go
@@ -2,6 +2,7 @@ package tar
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ func TestLocalInput(t *testing.T) {
 	assert.NoError(t, b.InitPipe(wr, nil))
 	assert.NoError(t, b.InitModule(&Config{DirectoryPath: "target"}))
 	assert.Equal(t, &Config{}, b.GetConfig())
-	assert.NoError(t, b.Run())
+	assert.NoError(t, b.Run(context.TODO()))
 	assert.NotNil(t, wr.Bytes())
 
 }

--- a/modules/backup/output/gcp/gcp.go
+++ b/modules/backup/output/gcp/gcp.go
@@ -1,8 +1,8 @@
 package gcp
 
 import (
-	"errors"
 	"context"
+	"errors"
 	"github.com/copybird/copybird/core"
 	"io"
 
@@ -17,12 +17,12 @@ const MODULE_NAME = "gcp"
 
 type BackupOutputGcp struct {
 	core.Module
-	ctx        context.Context
-	reader     io.Reader
-	writer     io.Writer
-	client     *storage.Client
-	bucket     *storage.BucketHandle
-	config     *Config
+	ctx    context.Context
+	reader io.Reader
+	writer io.Writer
+	client *storage.Client
+	bucket *storage.BucketHandle
+	config *Config
 }
 
 func (m *BackupOutputGcp) GetGroup() core.ModuleGroup {
@@ -86,7 +86,7 @@ func (m *BackupOutputGcp) InitModule(_config interface{}) error {
 	return nil
 }
 
-func (m *BackupOutputGcp) Run() error {
+func (m *BackupOutputGcp) Run(ctx context.Context) error {
 
 	obj := m.bucket.Object(m.config.File)
 	w := obj.NewWriter(m.ctx)

--- a/modules/backup/output/http/http.go
+++ b/modules/backup/output/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"io"
 	"net/http"
 
@@ -47,7 +48,7 @@ func (m *BackupOutputHttp) InitModule(cfg interface{}) error {
 	return nil
 }
 
-func (m *BackupOutputHttp) Run() error {
+func (m *BackupOutputHttp) Run(ctx context.Context) error {
 	resp, err := http.Post(m.config.TargetUrl, "application/json", m.reader)
 	if err != nil {
 		return err

--- a/modules/backup/output/http/http_test.go
+++ b/modules/backup/output/http/http_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,6 @@ func TestRun(t *testing.T) {
 	}
 	err := h.InitModule(conf)
 	require.NoError(t, err)
-	err = h.Run()
+	err = h.Run(context.TODO())
 	assert.NoError(t, err)
 }

--- a/modules/backup/output/local/local.go
+++ b/modules/backup/output/local/local.go
@@ -1,9 +1,11 @@
 package local
 
 import (
-	"github.com/copybird/copybird/core"
+	"context"
 	"io"
 	"os"
+
+	"github.com/copybird/copybird/core"
 )
 
 // Module Constants
@@ -48,7 +50,7 @@ func (m *BackupOutputLocal) InitModule(_config interface{}) error {
 	return nil
 }
 
-func (m *BackupOutputLocal) Run() error {
+func (m *BackupOutputLocal) Run(ctx context.Context) error {
 
 	// If the file doesn't exist, create it, or append to the file
 	f, err := os.OpenFile(m.config.File, m.config.DefaultMask, 0644)

--- a/modules/backup/output/local/local_test.go
+++ b/modules/backup/output/local/local_test.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestRun(t *testing.T) {
 	}
 	err := l.InitModule(conf)
 	require.NoError(t, err)
-	err = l.Run()
+	err = l.Run(context.TODO())
 	require.NoError(t, err)
 	os.Remove("test.txt")
 }

--- a/modules/backup/output/s3/s3.go
+++ b/modules/backup/output/s3/s3.go
@@ -1,13 +1,14 @@
 package s3
 
 import (
-	"github.com/copybird/copybird/core"
+	"context"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/copybird/copybird/core"
 )
 
 // Module Constants
@@ -59,7 +60,7 @@ func (m *BackupOutputS3) InitModule(_config interface{}) error {
 	return nil
 }
 
-func (m *BackupOutputS3) Run() error {
+func (m *BackupOutputS3) Run(ctx context.Context) error {
 
 	svc := s3manager.NewUploader(m.session)
 

--- a/modules/backup/output/scp/scp.go
+++ b/modules/backup/output/scp/scp.go
@@ -2,6 +2,7 @@ package scp
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/copybird/copybird/core"
 
 	"github.com/pkg/sftp"
-
 	"golang.org/x/crypto/ssh"
 )
 
@@ -115,7 +115,7 @@ func (m *BackupOutputScp) InitModule(_config interface{}) error {
 	return nil
 }
 
-func (m *BackupOutputScp) Run() error {
+func (m *BackupOutputScp) Run(ctx context.Context) error {
 
 	// create destination file
 	dstFile, err := m.client.Create(m.config.FileName)

--- a/modules/global/connect/ssh/ssh.go
+++ b/modules/global/connect/ssh/ssh.go
@@ -100,7 +100,7 @@ func (m *GlobalConnectSsh) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalConnectSsh) Run() error {
+func (m *GlobalConnectSsh) Run(ctx context.Context) error {
 	return m.tunnel.Start()
 }
 

--- a/modules/global/notifier/awsses/awsses.go
+++ b/modules/global/notifier/awsses/awsses.go
@@ -1,17 +1,18 @@
 package awsses
 
 import (
-	"github.com/copybird/copybird/core"
+	"context"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/copybird/copybird/core"
 )
 
 const (
-	GROUP_NAME = "global"
-	TYPE_NAME = "notifier"
+	GROUP_NAME  = "global"
+	TYPE_NAME   = "notifier"
 	MODULE_NAME = "awsses"
 )
 
@@ -93,7 +94,7 @@ func (m *GlobalNotifierAwsses) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierAwsses) Run() error {
+func (m *GlobalNotifierAwsses) Run(ctx context.Context) error {
 
 	// Attempt to send the email.
 	_, err := m.simem.SendEmail(m.seInput)

--- a/modules/global/notifier/awsses/awsses_test.go
+++ b/modules/global/notifier/awsses/awsses_test.go
@@ -1,6 +1,7 @@
 package awsses
 
 import (
+	"context"
 	"testing"
 
 	"gotest.tools/assert"
@@ -18,7 +19,7 @@ func TestAwsSes_NoCredentialProvErrs(t *testing.T) {
 	as := &GlobalNotifierAwsses{}
 	assert.Assert(t, as.GetConfig() != nil)
 	assert.NilError(t, as.InitModule(conf))
-	err := as.Run()
+	err := as.Run(context.TODO())
 	assert.Error(t, err, noCredErr)
 }
 
@@ -36,6 +37,6 @@ func TestAwsSes_WithCredential(t *testing.T) {
 	as := &GlobalNotifierAwsses{}
 	assert.Assert(t, as.GetConfig() != nil)
 	assert.NilError(t, as.InitModule(conf))
-	err := as.Run()
+	err := as.Run(context.TODO())
 	assert.Error(t, err, noCredErr)
 }

--- a/modules/global/notifier/awssqs/awssqs.go
+++ b/modules/global/notifier/awssqs/awssqs.go
@@ -1,6 +1,7 @@
 package awssqs
 
 import (
+	"context"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,7 +49,7 @@ func (m *GlobalNotifierAWSSQS) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierAWSSQS) Run() error {
+func (m *GlobalNotifierAWSSQS) Run(ctx context.Context) error {
 	if err := m.config.NotifyAWSSQS(); err != nil {
 		return err
 	}

--- a/modules/global/notifier/email/email.go
+++ b/modules/global/notifier/email/email.go
@@ -1,9 +1,11 @@
 package email
 
 import (
+	"context"
 	"fmt"
-	"github.com/copybird/copybird/core"
 	"net/smtp"
+
+	"github.com/copybird/copybird/core"
 )
 
 const GROUP_NAME = "global"
@@ -36,7 +38,7 @@ func (e *GlobalNotifierEmail) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (e *GlobalNotifierEmail) Run() error {
+func (e *GlobalNotifierEmail) Run(ctx context.Context) error {
 	if err := e.SendEmail(); err != nil {
 		return err
 	}

--- a/modules/global/notifier/kafka/kafka.go
+++ b/modules/global/notifier/kafka/kafka.go
@@ -1,10 +1,12 @@
 package kafka
 
 import (
-	"github.com/copybird/copybird/core"
 	"io"
-
+	"context"
+	
 	"github.com/Shopify/sarama"
+
+	"github.com/copybird/copybird/core"
 )
 
 const (
@@ -66,7 +68,7 @@ func (m *GlobalNotifieKafka) InitModule(_cfg interface{}) error {
 }
 
 // Run runs module
-func (m *GlobalNotifieKafka) Run() error {
+func (m *GlobalNotifieKafka) Run(ctx context.Context) error {
 	msg := &sarama.ProducerMessage{
 		Topic: m.config.Topic,
 		Value: sarama.StringEncoder(m.config.Message),

--- a/modules/global/notifier/kafka/kafka_test.go
+++ b/modules/global/notifier/kafka/kafka_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"testing"
+	"context"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -14,5 +15,5 @@ func TestKafka(t *testing.T) {
 	c.Topic = "hello"
 	c.Message = "world"
 	assert.NoError(t, k.InitModule(c))
-	assert.NoError(t, k.Run())
+	assert.NoError(t, k.Run(context.TODO()))
 }

--- a/modules/global/notifier/nats/nats.go
+++ b/modules/global/notifier/nats/nats.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	"context"
 	"errors"
 	"github.com/copybird/copybird/core"
 	"io"
@@ -9,8 +10,8 @@ import (
 )
 
 const (
-	GROUP_NAME = "global"
-	TYPE_NAME = "notifier"
+	GROUP_NAME  = "global"
+	TYPE_NAME   = "notifier"
 	MODULE_NAME = "nats"
 )
 
@@ -65,7 +66,7 @@ func (m *GlobalNotifierNats) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierNats) Run() error {
+func (m *GlobalNotifierNats) Run(ctx context.Context) error {
 	return m.conn.Publish(m.config.Topic, []byte(m.config.Msg))
 }
 

--- a/modules/global/notifier/nats/nats_test.go
+++ b/modules/global/notifier/nats/nats_test.go
@@ -1,6 +1,7 @@
 package nats
 
 import (
+	"context"
 	"testing"
 
 	"gotest.tools/assert"
@@ -33,7 +34,7 @@ func TestNats_ValidConn(t *testing.T) {
 		t.Errorf("TestNats: %v", err)
 	}
 
-	err = n.Run()
+	err = n.Run(context.TODO())
 	if err != nil {
 		t.Errorf("TestNats: %v", err)
 	}

--- a/modules/global/notifier/nsq/nsq.go
+++ b/modules/global/notifier/nsq/nsq.go
@@ -2,6 +2,7 @@ package nsq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,7 +53,7 @@ func (m *GlobalNotifierNSQ) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierNSQ) Run() error {
+func (m *GlobalNotifierNSQ) Run(ctx context.Context) error {
 	if err := m.config.NotifyNSQ(); err != nil {
 		return err
 	}

--- a/modules/global/notifier/nsq/nsq_test.go
+++ b/modules/global/notifier/nsq/nsq_test.go
@@ -2,6 +2,7 @@ package nsq
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -52,7 +53,7 @@ func TestNotifySlackChannel(t *testing.T) {
 		urls := fmt.Sprintf("%s=%s", NSQUrlSite, tt.TopicName)
 		httpmock.RegisterResponder("POST", urls, tt.Responder)
 		assert.NoError(t, n.InitModule(&Config{TopicName: tt.TopicName, Message: tt.Message}))
-		err := n.Run()
+		err := n.Run(context.TODO())
 		assert.Equal(t, tt.Error, err)
 	}
 }

--- a/modules/global/notifier/pagerduty/pagerduty.go
+++ b/modules/global/notifier/pagerduty/pagerduty.go
@@ -1,6 +1,8 @@
 package pagerduty
 
 import (
+	"context"
+
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/copybird/copybird/core"
 )
@@ -38,7 +40,7 @@ func (m *GlobalNotifierPagerDuty) InitModule(_conf interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierPagerDuty) Run() error {
+func (m *GlobalNotifierPagerDuty) Run(ctx context.Context) error {
 	_, err := m.client.CreateIncident(m.config.From, &pagerduty.CreateIncident{Incident: pagerduty.CreateIncidentOptions{
 		Type:  "dump creation status",
 		Title: "Test",

--- a/modules/global/notifier/pagerduty/pagerduty_test.go
+++ b/modules/global/notifier/pagerduty/pagerduty_test.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func TestRun(t *testing.T) {
 		From:      "example@example.com",
 	})
 	require.NoError(t, err, "should not be any error here")
-	err = n.Run()
+	err = n.Run(context.TODO())
 	require.Error(t, err)
 
 }

--- a/modules/global/notifier/pushbullet/pushbullet.go
+++ b/modules/global/notifier/pushbullet/pushbullet.go
@@ -1,6 +1,7 @@
 package pushbullet
 
 import (
+	"context"
 	"io"
 
 	"github.com/copybird/copybird/core"
@@ -46,7 +47,7 @@ func (m *GlobalNotifierPushbullet) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierPushbullet) Run() error {
+func (m *GlobalNotifierPushbullet) Run(ctx context.Context) error {
 	if err := m.config.NotifyPushbulletChannel(); err != nil {
 		return err
 	}

--- a/modules/global/notifier/rabbitmq/rabbitmq.go
+++ b/modules/global/notifier/rabbitmq/rabbitmq.go
@@ -1,15 +1,16 @@
 package rabbitmq
 
 import (
-	"github.com/copybird/copybird/core"
+	"context"
 	"io"
 
+	"github.com/copybird/copybird/core"
 	"github.com/streadway/amqp"
 )
 
 const (
-	GROUP_NAME = "global"
-	TYPE_NAME = "notifier"
+	GROUP_NAME  = "global"
+	TYPE_NAME   = "notifier"
 	MODULE_NAME = "rabbitmq"
 )
 
@@ -87,7 +88,7 @@ func (m *GlobalNotifierRabbitmq) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierRabbitmq) Run() error {
+func (m *GlobalNotifierRabbitmq) Run(ctx context.Context) error {
 	err := m.channel.Publish(
 		m.config.PublishExchange,  // exchange
 		m.config.PublishKey,       // routing key

--- a/modules/global/notifier/rabbitmq/rabbitmq_test.go
+++ b/modules/global/notifier/rabbitmq/rabbitmq_test.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"context"
 	"testing"
 
 	"gotest.tools/assert"
@@ -39,7 +40,7 @@ func TestRabbitMQ_ValidConn(t *testing.T) {
 		t.Errorf("TestRabbitMQ: %v", err)
 	}
 
-	err = rmq.Run()
+	err = rmq.Run(context.TODO())
 	if err != nil {
 		t.Errorf("TestRabbitMQ: %v", err)
 	}

--- a/modules/global/notifier/slack/slack.go
+++ b/modules/global/notifier/slack/slack.go
@@ -2,17 +2,19 @@ package slack
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/copybird/copybird/core"
 	"io"
 	"net/http"
+
+	"github.com/copybird/copybird/core"
 )
 
 const (
-	GROUP_NAME = "global"
-	TYPE_NAME = "notifier"
+	GROUP_NAME          = "global"
+	TYPE_NAME           = "notifier"
 	MODULE_NAME         = "slack"
 	SlackHookSite       = "https://hooks.slack.com/services"
 	HeaderContentType   = "Content-Type"
@@ -53,7 +55,7 @@ func (m *GlobalNotifierSlack) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierSlack) Run() error {
+func (m *GlobalNotifierSlack) Run(ctx context.Context) error {
 	if err := m.config.NotifySlackChannel(); err != nil {
 		return err
 	}

--- a/modules/global/notifier/slack/slack_test.go
+++ b/modules/global/notifier/slack/slack_test.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -54,7 +55,7 @@ func TestNotifySlackChannel(t *testing.T) {
 		urls := fmt.Sprintf("%s/%s", SlackHookSite, tt.Hook)
 		httpmock.RegisterResponder("POST", urls, tt.Responder)
 		assert.NoError(t, n.InitModule(&Config{Hook: tt.Hook, MessageSuccess: tt.Message, Success: tt.Success}))
-		err := n.Run()
+		err := n.Run(context.TODO())
 		assert.Equal(t, tt.Error, err)
 	}
 }
@@ -80,7 +81,7 @@ func TestRun(t *testing.T) {
 		urls := fmt.Sprintf("%s/%s", SlackHookSite, tt.Hook)
 		httpmock.RegisterResponder("POST", urls, tt.Responder)
 		assert.NoError(t, n.InitModule(&Config{Hook: tt.Hook, MessageSuccess: tt.Message, Success: tt.Success}))
-		err := n.Run()
+		err := n.Run(context.TODO())
 		assert.Equal(t, tt.Error, err)
 	}
 }

--- a/modules/global/notifier/telegram/telegram.go
+++ b/modules/global/notifier/telegram/telegram.go
@@ -1,11 +1,13 @@
 package telegram
 
 import (
-	"github.com/copybird/copybird/core"
+	"context"
 	"io"
 	"log"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+
+	"github.com/copybird/copybird/core"
 )
 
 const GROUP_NAME = "global"
@@ -42,7 +44,7 @@ func (m *GlobalNotifierTelegram) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierTelegram) Run() error {
+func (m *GlobalNotifierTelegram) Run(ctx context.Context) error {
 	if err := m.config.NotifyTelegramChannel(); err != nil {
 		return err
 	}

--- a/modules/global/notifier/twilio/twilio.go
+++ b/modules/global/notifier/twilio/twilio.go
@@ -1,6 +1,7 @@
 package twillio
 
 import (
+	"context"
 	"errors"
 
 	"github.com/copybird/copybird/core"
@@ -40,7 +41,7 @@ func (t *GlobalNotifierTwilio) InitModule(_conf interface{}) error {
 	return nil
 }
 
-func (t *GlobalNotifierTwilio) Run() error {
+func (t *GlobalNotifierTwilio) Run(ctx context.Context) error {
 
 	_, exception, err := t.client.SendSMS(t.config.From, t.config.To, "Dump created successfully", "", "")
 	if err != nil {

--- a/modules/global/notifier/webcallback/webcallback.go
+++ b/modules/global/notifier/webcallback/webcallback.go
@@ -1,13 +1,15 @@
 package webcallback
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"github.com/copybird/copybird/core"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/copybird/copybird/core"
 )
 
 const GROUP_NAME = "global"
@@ -40,7 +42,7 @@ func (m *GlobalNotifierWebcallback) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *GlobalNotifierWebcallback) Run() error {
+func (m *GlobalNotifierWebcallback) Run(ctx context.Context) error {
 	if err := m.SendNotification(); err != nil {
 		return err
 	}

--- a/modules/restore/decompress/gzip/gzip.go
+++ b/modules/restore/decompress/gzip/gzip.go
@@ -2,9 +2,11 @@ package gzip
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
-	"github.com/copybird/copybird/core"
 	"io"
+
+	"github.com/copybird/copybird/core"
 )
 
 const GROUP_NAME = "restore"
@@ -43,7 +45,7 @@ func (m *RestoreDecompressGzip) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *RestoreDecompressGzip) Run() error {
+func (m *RestoreDecompressGzip) Run(ctx context.Context) error {
 	gr, err := gzip.NewReader(m.reader)
 	if err != nil {
 		return fmt.Errorf("cant start gzip reader with error: %s", err)

--- a/modules/restore/decompress/gzip/gzip_test.go
+++ b/modules/restore/decompress/gzip/gzip_test.go
@@ -2,6 +2,7 @@ package gzip
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ func TestCompress_Unzip_Success_Unzip(t *testing.T) {
 
 	_ = decompressor.InitModule(nil)
 	_ = decompressor.InitPipe(&wr, rd)
-	err := decompressor.Run()
+	err := decompressor.Run(context.TODO())
 	assert.Equal(t, err, nil)
 	assert.Equal(t, wr.String(), "hello world\n")
 }
@@ -38,7 +39,7 @@ func TestCompress_Unzip_Unsuccess_Unzip(t *testing.T) {
 
 	_ = decompressor.InitModule(nil)
 	_ = decompressor.InitPipe(&wr, rd)
-	err := decompressor.Run()
+	err := decompressor.Run(context.TODO())
 	assert.NotEqual(t, err, nil)
 	assert.Equal(t, wr.String(), "")
 }

--- a/modules/restore/decompress/lz4/lz4.go
+++ b/modules/restore/decompress/lz4/lz4.go
@@ -1,12 +1,12 @@
 package lz4
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"github.com/copybird/copybird/core"
 	"io"
 
-	// "os"
+	"github.com/copybird/copybird/core"
 
 	"github.com/pierrec/lz4"
 )
@@ -53,7 +53,7 @@ func (m *RestoreDecompressLz4) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *RestoreDecompressLz4) Run() error {
+func (m *RestoreDecompressLz4) Run(ctx context.Context) error {
 	// make a buffer to keep chunks that are read
 	lr := lz4.NewReader(m.reader)
 

--- a/modules/restore/decompress/lz4/lz4_test.go
+++ b/modules/restore/decompress/lz4/lz4_test.go
@@ -2,6 +2,7 @@ package lz4
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -40,7 +41,7 @@ Wu got it locked, performin' live on your hottest block`
 
 	assert.NoError(t, decompressor.InitModule(nil))
 	assert.NoError(t, decompressor.InitPipe(wr, rd))
-	assert.NoError(t, decompressor.Run())
+	assert.NoError(t, decompressor.Run(context.TODO()))
 	spew.Dump(wr)
 
 	assert.Equal(t, wr.String(), "hello world")

--- a/modules/restore/decrypt/aesgcm/aesgcm.go
+++ b/modules/restore/decrypt/aesgcm/aesgcm.go
@@ -1,6 +1,7 @@
 package aesgcm
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -71,7 +72,7 @@ func (m *RestoreDecryptAesgcm) InitModule(_cfg interface{}) error {
 	return nil
 }
 
-func (m *RestoreDecryptAesgcm) Run() error {
+func (m *RestoreDecryptAesgcm) Run(ctx context.Context) error {
 	var err error
 	buf := make([]byte, 16)
 	bufOut := make([]byte, 16)

--- a/modules/restore/decrypt/aesgcm/aesgcm_test.go
+++ b/modules/restore/decrypt/aesgcm/aesgcm_test.go
@@ -2,6 +2,7 @@ package aesgcm
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"gotest.tools/assert"
@@ -16,6 +17,6 @@ func TestEncryptionAESGCM(t *testing.T) {
 	assert.Assert(t, enc.GetConfig() != nil)
 	assert.NilError(t, enc.InitPipe(bufOutput, bufInput))
 	assert.NilError(t, enc.InitModule(&Config{Key: key}))
-	assert.NilError(t, enc.Run())
+	assert.NilError(t, enc.Run(context.TODO()))
 	assert.NilError(t, enc.Close())
 }

--- a/modules/restore/output/mysql/mysql.go
+++ b/modules/restore/output/mysql/mysql.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"io"
 
@@ -74,7 +75,7 @@ func (m *RestoreOutputMysql) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (m *RestoreOutputMysql) Run() error {
+func (m *RestoreOutputMysql) Run(ctx context.Context) error {
 	return m.RestoreDatabase()
 }
 

--- a/modules/restore/output/mysql/mysql_test.go
+++ b/modules/restore/output/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestRestoreOutputMysql_Run(t *testing.T) {
 	f, _ := os.Open("../../../../samples/mysql.sql")
 	rs.InitPipe(nil, f)
 
-	err = rs.Run()
+	err = rs.Run(context.TODO())
 	if err != nil {
 		print(err.Error())
 	}

--- a/modules/restore/output/postgresql/postgresql.go
+++ b/modules/restore/output/postgresql/postgresql.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"io"
 
@@ -68,7 +69,7 @@ func (r *RestoreOutputPostgresql) InitModule(cfg interface{}) error {
 }
 
 // Run dumps database
-func (r *RestoreOutputPostgresql) Run() error {
+func (r *RestoreOutputPostgresql) Run(ctx context.Context) error {
 	tokenizer := sqlparser.NewTokenizer(r.reader)
 
 	for {

--- a/modules/restore/output/postgresql/postgresql_test.go
+++ b/modules/restore/output/postgresql/postgresql_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -23,6 +24,6 @@ func TestRestoreOutputPostgresql_Run(t *testing.T) {
 
 	f, _ := os.Open("../../../../samples/postgres.sql")
 	rs.InitPipe(nil, f)
-	err = rs.Run()
+	err = rs.Run(context.TODO())
 	assert.Equal(t, err, nil)
 }


### PR DESCRIPTION
Module's interface `Run` method now accepts context.Context as the parameter to control execution flow 